### PR TITLE
Sct 857

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/kbase:sdkbase.latest
+FROM kbase/kbase:sdkbase2.latest
 MAINTAINER KBase Developer
 # -----------------------------------------
 # In this section, you can install any system dependencies required
@@ -10,11 +10,6 @@ MAINTAINER KBase Developer
 
 # Here we install a python coverage tool
 RUN pip install coverage
-
-# Fix Python SSL warnings for python < 2.7.9 (system python on Trusty is 2.7.6)
-# https://github.com/pypa/pip/issues/4098
-RUN pip install pip==8.1.2
-RUN pip install --disable-pip-version-check requests requests_toolbelt pyopenssl --upgrade
 
 RUN pip install pathos
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,4 +22,9 @@ Fix memory issue and add parallel for genome processing
 1.0.9:
 Fix same genome name issue
 
+1.0.10:
+Compatibility with new genome
+
+1.0.11:
+Fix multiprocessing pickling problem
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.10
+    1.0.11
 
 owners:
     [tgu2]

--- a/lib/PanGenomeAPI/PanGenomeViewer.py
+++ b/lib/PanGenomeAPI/PanGenomeViewer.py
@@ -67,8 +67,12 @@ class PanGenomeViewer:
 
         genome_gene_map = {}
         ortholog_ids = []
-        object_info = self.ws.get_objects2({'objects': 
-                                           [{'ref': genome_ref}]})['data'][0]['data']
+        try:
+            object_info = self.ws.get_objects2(
+                {'objects': [{'ref': genome_ref}]}
+            )['data'][0]['data']
+        except Exception as e:
+            raise RuntimeError("Error in accessing WS objects: %s" % e)
 
         scientific_name = object_info.get('scientific_name')
         if scientific_name:

--- a/test/PanGenomeAPI_server_test.py
+++ b/test/PanGenomeAPI_server_test.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
-import unittest
 import os  # noqa: F401
-import json  # noqa: F401
-import time
-import requests  # noqa: F401
 import shutil
-
+import time
+import unittest
 from os import environ
+from pprint import pprint  # noqa: F401
 try:
     from ConfigParser import ConfigParser  # py2
-except:
+except ImportError:
     from configparser import ConfigParser  # py3
-
-from pprint import pprint  # noqa: F401
 
 from Bio import SeqIO
 


### PR DESCRIPTION
The Pangenome API fas failing on a particular papangenome with the the following cryptic error:
`02 2018-04-13T17:39:21.802282194Z Exception in thread Thread-7: 
02 2018-04-13T17:39:21.802345236Z Traceback (most recent call last): 
02 2018-04-13T17:39:21.802358913Z File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner 
02 2018-04-13T17:39:21.802370283Z self.run() 
02 2018-04-13T17:39:21.802380230Z File "/usr/lib/python2.7/threading.py", line 763, in run 
02 2018-04-13T17:39:21.802391316Z self._target(*self.args, **self._kwargs) 
02 2018-04-13T17:39:21.802401776Z File "/usr/local/lib/python2.7/dist-packages/multiprocess/pool.py", line 389, in _handle_results 
02 2018-04-13T17:39:21.802412559Z task = get() 
02 2018-04-13T17:39:21.802422839Z File "/usr/local/lib/python2.7/dist-packages/dill/dill.py", line 299, in loads 
02 2018-04-13T17:39:21.802458099Z return load(file) 
02 2018-04-13T17:39:21.802470422Z File "/usr/local/lib/python2.7/dist-packages/dill/dill.py", line 288, in load 
02 2018-04-13T17:39:21.802481139Z obj = pik.load() 
02 2018-04-13T17:39:21.802491965Z File "/usr/lib/python2.7/pickle.py", line 858, in load 
02 2018-04-13T17:39:21.802517658Z dispatch[key](self) 
02 2018-04-13T17:39:21.802528254Z File "/usr/lib/python2.7/pickle.py", line 1133, in load_reduce 
02 2018-04-13T17:39:21.802538858Z value = func(*args) 
02 2018-04-13T17:39:21.802548788Z TypeError: _init_() takes at least 4 arguments (2 given) 
02 2018-04-13T17:39:21.802559431Z`

I traced the issue back to this bug where custom exceptions fail to pickle properly: https://bugs.python.org/issue9400#msg112329

In our case, the issue was a JSONRPCError that noted that a workspace was not viewable. This PR re-raises these errors as type RuntypeError while retaining the original exception & traceback. I also updated the Dockerfile and test imports in the process of my debugging.