### PR TITLE
Clean up summary function

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -1,0 +1,62 @@
+name: KBase SDK Tests
+
+on:
+  push:
+    branches:
+    - master
+    - main
+  pull_request:
+    branches:
+    - master
+    - main
+    - develop
+
+jobs:
+
+  sdk_tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out GitHub repo
+      if: "!contains(github.event.head_commit.message, 'skip ci')"
+      uses: actions/checkout@v2
+
+    - name: Check out Actions CI files
+      if: "!contains(github.event.head_commit.message, 'skip ci')"
+      uses: actions/checkout@v2
+      with:
+        repository: 'kbaseapps/kb_sdk_actions'
+        path: 'kb_sdk_actions'
+
+
+    - name: Set up test environment
+      if: "!contains(github.event.head_commit.message, 'skip ci')"
+      shell: bash
+      env:
+        KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+      run: |
+        # Verify kb_sdk_actions clone worked
+        test -f "$HOME/kb_sdk_actions/bin/kb-sdk" && echo "CI files cloned"
+        # Pull kb-sdk & create startup script
+        docker pull kbase/kb-sdk
+       
+        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir && echo "Created test_local"
+        test -f "test_local/test.cfg" && echo "Confirmed config exists"
+
+    - name: Configure authentication
+      if: "!contains(github.event.head_commit.message, 'skip ci')"
+      shell: bash
+      env:
+        KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+      run: |
+        # Add token to config
+        sed -ie "s/^test_token=.*$/&$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
+
+    - name: Run tests
+      if: "!contains(github.event.head_commit.message, 'skip ci')"
+      shell: bash
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
+        bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: 
-env:
-before_install:
-install:
-script:
-after_script:

--- a/PanGenomeAPI.spec
+++ b/PanGenomeAPI.spec
@@ -189,6 +189,81 @@ module PanGenomeAPI {
         int genomes;
     } ComputeSummaryFromPGResult;
 
+    /* @deprecated compute_summary_from_pangenome2 */
     funcdef compute_summary_from_pangenome(ComputeSummaryFromPG params) 
         returns (ComputeSummaryFromPGResult result) authentication optional;
+
+    /*
+     * Report of gene counts for a pangenome, or a subset within a pangenome.
+     * Properties:
+     *     genes_count: total number of genes
+     *     homolog_family_genes_count: total number of genes in non-singleton families
+     *     singleton_family_genes_count: total number of genes in families with only one member
+     */
+    typedef structure {
+        int genes_count;
+        int homolog_family_genes_count;
+        int singleton_family_genes_count;
+    } GeneFamilyReport;
+
+    /* Report of counts for each homolog family
+     * A lot of this is redundant with GeneFamilyReport, but included for backwards compatibility.
+     * Properties:
+     *     families_counts: total count of homolog families
+     *     homolog_families_count: total count of non-singleton families (TODO is this right?)
+     *     singleton_families_count: total count of singleton families
+     */
+    typedef structure {
+        int families_count;
+        int homolog_families_count;
+        int singleton_families_count;
+    } FamilyReport;
+
+    /*
+     * This is the same as GeneFamilyReport with different keys. This only
+     * exists for frontend compatibility reasons.
+     * Properties:
+     *   genome_genes: total count of genes
+     *   genome_homolog_family_genes: total count of genes in non-singleton families
+     *   genome_singleton_family_genes: total count of genes in singleton families
+     *   genome_homolog_family: total count of homolog families
+     */
+    typedef structure {
+        int genome_genes;
+        int genome_homolog_family_genes;
+        int genome_singleton_family_genes;
+        int genome_homolog_family;
+    } GenomeGeneFamilyReport;
+
+    /*
+     * Return type for the compute_summary_from_pangenome2 function.
+     * Much of this matches the ComputeSummaryFromPG type, with some corrections.
+     * Properties:
+     *     pangenome_id: string identifier from the Pangenome object (under data/id)
+     *     genomes_count: total genomes included in this pangenome
+     *     genes: counts of total genes, families, and singletons in the pangenome
+     *     families: counts of total families and single families
+     *     genomes: mapping of genome workspace reference to gene/family counts for each
+     *     shared_family_map: 
+     *         mapping of genome IDs to other genome IDs, with the nested
+     *         values being the count of shared gene families. For example:
+     *         {"1": {"2": 10}} says that genome "1" and genome "2" have 10
+     *         shared gene families.
+     *     genome_ref_name_map: 
+     *         mapping from genome refs to a unique displayable/readable string
+     *         that includes the scientific and object names for each genome.
+     */
+    typedef structure {
+        string pangenome_id;
+        int genomes_count;
+        GeneFamilyReport genes;
+        FamilyReport families;
+        mapping<string, GenomeGeneFamilyReport> genomes;
+        mapping<string, mapping<string, int>> shared_family_map;
+        mapping<string, string> genome_ref_name_map;
+    } Summary2Result;
+
+    /* Compute a summary of the pangenome, with various counts and aggregations. */
+    funcdef compute_summary_from_pangenome2(ComputeSummaryFromPG params) 
+        returns (Summary2Result result) authentication optional;
 };

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,3 +33,7 @@ Update to Python 3
 
 1.1.1:
 Update server to support longer running tasks with longer timeouts.
+
+1.2.1:
+Add the function `compute_summary_from_pangenome2` which improves performance
+over the previous function.

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.1.1
+    1.2.1
 
 owners:
     [tgu2]

--- a/lib/PanGenomeAPI/PanGenomeAPIImpl.py
+++ b/lib/PanGenomeAPI/PanGenomeAPIImpl.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
 from PanGenomeAPI.PanGenomeIndexer import PanGenomeIndexer
-import os
+from PanGenomeAPI.fetch_summary.main import fetch_pangenome_summary
 #END_HEADER
 
 
@@ -20,9 +20,9 @@ class PanGenomeAPI:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.1.0"
-    GIT_URL = "https://github.com/kbaseapps/PanGenomeAPI.git"
-    GIT_COMMIT_HASH = "6aa52d10d28fc46e3762cfc6df34be20ae8deef6"
+    VERSION = "1.2.1"
+    GIT_URL = "https://github.com/kbaseapps/PanGenomeAPI"
+    GIT_COMMIT_HASH = "44d57aa82618e61624cd882e7f3f5ee91ea93b96"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -31,6 +31,7 @@ class PanGenomeAPI:
     # be found
     def __init__(self, config):
         #BEGIN_CONSTRUCTOR
+        self.config = config
         self.indexer = PanGenomeIndexer(config)
         #END_CONSTRUCTOR
         pass
@@ -215,6 +216,7 @@ class PanGenomeAPI:
 
     def compute_summary_from_pangenome(self, ctx, params):
         """
+        @deprecated compute_summary_from_pangenome2
         :param params: instance of type "ComputeSummaryFromPG" -> structure:
            parameter "pangenome_ref" of String
         :returns: instance of type "ComputeSummaryFromPGResult" -> structure:
@@ -236,6 +238,77 @@ class PanGenomeAPI:
         # At some point might do deeper type checking...
         if not isinstance(result, dict):
             raise ValueError('Method compute_summary_from_pangenome return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
+
+    def compute_summary_from_pangenome2(self, ctx, params):
+        """
+        Compute a summary of the pangenome, with various counts and aggregations.
+        :param params: instance of type "ComputeSummaryFromPG" -> structure:
+           parameter "pangenome_ref" of String
+        :returns: instance of type "Summary2Result" (* Return type for the
+           compute_summary_from_pangenome2 function. * Much of this matches
+           the ComputeSummaryFromPG type, with some corrections. *
+           Properties: *     pangenome_id: string identifier from the
+           Pangenome object (under data/id) *     genomes_count: total
+           genomes included in this pangenome *     genes: counts of total
+           genes, families, and singletons in the pangenome *     families:
+           counts of total families and single families *     genomes:
+           mapping of genome workspace reference to gene/family counts for
+           each *     shared_family_map: *         mapping of genome IDs to
+           other genome IDs, with the nested *         values being the count
+           of shared gene families. For example: *         {"1": {"2": 10}}
+           says that genome "1" and genome "2" have 10 *         shared gene
+           families. *     genome_ref_name_map: *         mapping from genome
+           refs to a unique displayable/readable string *         that
+           includes the scientific and object names for each genome.) ->
+           structure: parameter "pangenome_id" of String, parameter
+           "genomes_count" of Long, parameter "genes" of type
+           "GeneFamilyReport" (* Report of gene counts for a pangenome, or a
+           subset within a pangenome. * Properties: *     genes_count: total
+           number of genes *     homolog_family_genes_count: total number of
+           genes in non-singleton families *    
+           singleton_family_genes_count: total number of genes in families
+           with only one member) -> structure: parameter "genes_count" of
+           Long, parameter "homolog_family_genes_count" of Long, parameter
+           "singleton_family_genes_count" of Long, parameter "families" of
+           type "FamilyReport" (Report of counts for each homolog family * A
+           lot of this is redundant with GeneFamilyReport, but included for
+           backwards compatibility. * Properties: *     families_counts:
+           total count of homolog families *     homolog_families_count:
+           total count of non-singleton families (TODO is this right?) *    
+           singleton_families_count: total count of singleton families) ->
+           structure: parameter "families_count" of Long, parameter
+           "homolog_families_count" of Long, parameter
+           "singleton_families_count" of Long, parameter "genomes" of mapping
+           from String to type "GenomeGeneFamilyReport" (* This is the same
+           as GeneFamilyReport with different keys. This only * exists for
+           frontend compatibility reasons. * Properties: *   genome_genes:
+           total count of genes *   genome_homolog_family_genes: total count
+           of genes in non-singleton families *  
+           genome_singleton_family_genes: total count of genes in singleton
+           families *   genome_homolog_family: total count of homolog
+           families) -> structure: parameter "genome_genes" of Long,
+           parameter "genome_homolog_family_genes" of Long, parameter
+           "genome_singleton_family_genes" of Long, parameter
+           "genome_homolog_family" of Long, parameter "shared_family_map" of
+           mapping from String to mapping from String to Long, parameter
+           "genome_ref_name_map" of mapping from String to String
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN compute_summary_from_pangenome2
+        result = fetch_pangenome_summary(
+            params["pangenome_ref"],
+            self.config["workspace-url"],
+            ctx["token"],
+        )
+        #END compute_summary_from_pangenome2
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method compute_summary_from_pangenome2 return value ' +
                              'result is not type dict as required.')
         # return the results
         return [result]

--- a/lib/PanGenomeAPI/PanGenomeAPIServer.py
+++ b/lib/PanGenomeAPI/PanGenomeAPIServer.py
@@ -358,6 +358,10 @@ class Application(object):
                              name='PanGenomeAPI.compute_summary_from_pangenome',
                              types=[dict])
         self.method_authentication['PanGenomeAPI.compute_summary_from_pangenome'] = 'optional'  # noqa
+        self.rpc_service.add(impl_PanGenomeAPI.compute_summary_from_pangenome2,
+                             name='PanGenomeAPI.compute_summary_from_pangenome2',
+                             types=[dict])
+        self.method_authentication['PanGenomeAPI.compute_summary_from_pangenome2'] = 'optional'  # noqa
         self.rpc_service.add(impl_PanGenomeAPI.status,
                              name='PanGenomeAPI.status',
                              types=[dict])

--- a/lib/PanGenomeAPI/fetch_summary/main.py
+++ b/lib/PanGenomeAPI/fetch_summary/main.py
@@ -1,0 +1,222 @@
+"""
+Fetch and construct summary data for previewing a pangenome.
+"""
+from installed_clients.WorkspaceClient import Workspace as Workspace
+
+
+def fetch_pangenome_summary(
+        pangenome_ref: str,
+        workspace_url: str,
+        token: str) -> dict:
+    """
+    Construct a summary data object for a single pangenome, used in the
+    "simple_summary" method.
+    Args:
+        pangenome_ref: Workspace reference to the pangenome object
+        workspace_url: URL of the Workspace being used in the current env
+        token: authorization token for fetching the data
+    Returns:
+        A python object adhering to the SimpleSummaryResult type in
+        PanGenomeAPI.spec
+    """
+    ws_client = Workspace(workspace_url, token=token)
+    # Download the full pangenome workspace dataset
+    resp = ws_client.get_objects2({
+        'objects': [{'ref': pangenome_ref}]
+    })
+    data = resp['data'][0]['data']
+    # Fetch the object infos for each genome
+    genome_refs = [{"ref": ref} for ref in data["genome_refs"]]
+    genome_infos = ws_client.get_object_info3({
+        "objects": genome_refs,
+        "includeMetadata": 1
+    })["infos"]
+    name_mapping = _genome_name_mapping(genome_infos)
+    ret = {
+        "pangenome_id": data["id"],
+        "genomes_count": len(data["genome_refs"]),
+        "genes": _count_genes(data),
+        "families": _count_families(data),
+        "genomes": _genome_counts(data, genome_infos, name_mapping),
+        "shared_family_map": _shared_family_map(data, name_mapping),
+        "genome_ref_name_map": name_mapping,
+    }
+    return ret
+
+
+def _count_genes(pg_data: dict) -> dict:
+    """
+    Calculate gene counts for a pangenome object
+    Args:
+        pg_data: workspace data object for the Pangenome
+    Returns:
+        Dict of counts with the GeneFamilyReport type in PanGenomeAPI.spec
+    """
+    counts = {
+        "genes_count": 0,
+        "homolog_family_genes_count": 0,
+        "singleton_family_genes_count": 0,
+    }
+    for family in pg_data["orthologs"]:
+        count = len(family["orthologs"])
+        counts["genes_count"] += count
+        if count == 1:
+            counts["singleton_family_genes_count"] += count
+        elif count > 1:
+            counts["homolog_family_genes_count"] += count
+    return counts
+
+
+def _count_families(pg_data: dict) -> dict:
+    """
+    Aggregate counts for the homolog families in the pangenome
+    Args:
+        pg_data: workspace data object for the Pangenome
+    Returns:
+        dict matching the type FamilyReport from PanGenomeAPI.spec
+    """
+    counts = {
+        "families_count": 0,
+        "homolog_families_count": 0,
+        "singleton_families_count": 0,
+    }
+    counts["families_count"] = len(pg_data["orthologs"])
+    for family in pg_data["orthologs"]:
+        count = len(family["orthologs"])
+        if count == 1:
+            counts["singleton_families_count"] += 1
+        elif count > 1:
+            counts["homolog_families_count"] += 1
+    return counts
+
+
+def _genome_name_mapping(genome_infos: list) -> dict:
+    """
+    Construct a mapping of genome workspace reference to sciname
+    Args:
+        pg_data: workspace data object for the Pangenome
+        genome_infos: list of object info tuples (with metadata) for every
+            genome in the pangenome
+    Returns:
+        Mapping of genome ref to scientific name and obj name
+    """
+    ret = {}
+    names = set()
+    # Fetch the object infos for every ref
+    for info in genome_infos:
+        ref = _get_ref(info)
+        sciname = info[-1].get("Name", "unknown taxon")
+        # Create a unique display name for each genome
+        name = sciname
+        if name in names:
+            name = f"{sciname} ({ref})"
+        names.add(name)
+        ret[ref] = name
+    return ret
+
+
+def _genome_counts(
+        pg_data: dict,
+        genome_infos: list,
+        name_mapping: dict) -> dict:
+    """
+    Aggregate counts of genes and families for every genome
+    Args:
+        pg_data: workspace data object for the Pangenome
+        genome_infos: list of genome info tuples for each object
+        name_mapping: mapping of workspace ref to readable name for use as keys
+    Returns:
+        Mapping of genome ref to GenomeGeneFamilyReport (from
+        PanGenomeAPI.spec)
+    """
+    # Initialize the result structure
+    ret = {}
+    for name in name_mapping.values():
+        ret[name] = {
+            "genome_genes": 0,
+            "genome_homolog_family_genes": 0,
+            "genome_singleton_family_genes": 0,
+            "genome_homolog_family": 0,
+        }
+    # Set total feature counts from the obj info
+    for info in genome_infos:
+        key = name_mapping[_get_ref(info)]
+        ret[key]["genome_genes"] = _get_feature_count(info)
+    # Aggregate other counts from the ortholog families
+    for family in pg_data["orthologs"]:
+        count = len(family["orthologs"])
+        found_genomes = set()
+        for gene in family["orthologs"]:
+            genome_ref = gene[2]
+            key = name_mapping[genome_ref]
+            if count > 1:
+                ret[key]["genome_homolog_family_genes"] += 1
+                found_genomes.add(genome_ref)
+        for ref in found_genomes:
+            ret[name_mapping[ref]]["genome_homolog_family"] += 1
+    # Set the singleton family gene counts to be the difference of the total
+    # features and the homolog family counts
+    for ref in pg_data["genome_refs"]:
+        key = name_mapping[ref]
+        total = ret[key]["genome_genes"]
+        homologs = ret[key]["genome_homolog_family_genes"]
+        ret[key]["genome_singleton_family_genes"] = total - homologs
+    return ret
+
+
+def _shared_family_map(pg_data: dict, name_mapping: dict) -> dict:
+    """
+    Calculate the number of shared ortholog families between any two genomes
+    Args:
+        pg_data: workspace data object for the Pangenome
+        name_mapping: mapping of workspace ref to readable name for use as keys
+    Returns:
+        dict where keys are genome refs, and values are mapping of genome refs
+        to shared family counts.
+        Example: {"1": {"2": 10}} represents genome "1" and "2" sharing 10
+        families
+    """
+    # Initialize the return structure
+    ret = {}
+    for ref1 in pg_data["genome_refs"]:
+        key1 = name_mapping[ref1]
+        ret[key1] = {}
+        for ref2 in pg_data["genome_refs"]:
+            key2 = name_mapping[ref2]
+            ret[key1][key2] = 0
+    # Aggregate counts of all genomes that share genes in an ortholog family
+    for family in pg_data["orthologs"]:
+        if len(family["orthologs"]) <= 1:
+            # We only record non-singletons
+            continue
+        genome_refs = set(orth[2] for orth in family["orthologs"])
+        for ref1 in genome_refs:
+            for ref2 in genome_refs:
+                key1, key2 = name_mapping[ref1], name_mapping[ref2]
+                ret[key1][key2] += 1
+    return ret
+
+
+def _get_feature_count(genome_info: dict) -> int:
+    """
+    Get the total feature count (coding and non-coding) for a genome.
+    We fetch this number from the genome metadata.
+    Older Genome versions store this as "Number features", while newer versions
+    (>=9) store it as "Number of Protein Encoding Genes".
+    Genome versions before 8 (older than July, 2014) have no metadata and
+    aren't supported for now.
+    """
+    valid_keys = ("Number of Protein Encoding Genes", "Number features")
+    meta = genome_info[-1]
+    for key in valid_keys:
+        if key in meta:
+            return int(meta[key])
+    # TODO fallback to something else?
+    raise RuntimeError(
+        "Unable to read the number of features "
+        f"from the Genome metadata: {genome_info}")
+
+
+def _get_ref(info: list) -> str:
+    """Get the workspace reference from an info tuple"""
+    return f"{info[6]}/{info[0]}/{info[4]}"

--- a/test/PanGenomeAPI_server_test.py
+++ b/test/PanGenomeAPI_server_test.py
@@ -497,12 +497,21 @@ class PanGenomeAPITest(unittest.TestCase):
         self.assertIn('functions', ret['genomes'][0])
 
     def test_compute_summary_from_pangenome2_valid(self):
-        # Test object lives in a dedicated public test narrative owned by user `kbasedata`
-        ref = "51489/10/1"
-        params = {"pangenome_ref": ref}
-        ret = self.getImpl().compute_summary_from_pangenome2(self.getContext(), params)[0]
-        path = os.path.join(_TEST_DIR, "data", "summary2_expected_result.json")
-        # Assert against a full example object found in test/data/summary2_expected_result.json
-        with open(path) as fd:
-            expected = json.load(fd)
-        self.assertEqual(ret, expected)
+        # Test objects live in a dedicated public test narrative owned by user `kbasedata`
+        refs = ("51489/10/1", "51489/14/1", "51489/15/1")
+        for ref in refs:
+            params = {"pangenome_ref": ref}
+            ret = self.getImpl().compute_summary_from_pangenome2(self.getContext(), params)[0]
+            filename = f"summary2_expected_{ref.replace('/', '-')}.json"
+            path = os.path.join(_TEST_DIR, "data", filename)
+            # Assert against a full example object found in test/data/summary2_expected_result.json
+            with open(path) as fd:
+                expected = json.load(fd)
+            self.assertEqual(ret, expected)
+
+    def test_compute_summary_from_pangenome2_invalid_aprams(self):
+        params = ({"pangenome_ref": 0}, None, {"xyz": 123})
+        ctx = self.getContext()
+        for param in params:
+            with self.assertRaises(Exception):
+                self.getImpl().compute_summary_from_pangenome2(ctx, param)

--- a/test/PanGenomeAPI_server_test.py
+++ b/test/PanGenomeAPI_server_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os  # noqa: F401
+import json
 import shutil
 import time
 import unittest
@@ -15,6 +16,8 @@ from PanGenomeAPI.authclient import KBaseAuth as _KBaseAuth
 from installed_clients.GenomeAnnotationAPIClient import GenomeAnnotationAPI
 from installed_clients.GenomeComparisonSDKClient import GenomeComparisonSDK
 from installed_clients.WorkspaceClient import Workspace as workspaceService
+
+_TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 class PanGenomeAPITest(unittest.TestCase):
@@ -80,8 +83,7 @@ class PanGenomeAPITest(unittest.TestCase):
         cls.genome_refs = []
         genome_feature_counts = {}
         for genome_index, genome_file_name in enumerate(genome_fasta_files):
-            test_dir = os.path.dirname(os.path.realpath(__file__))
-            file_path = test_dir + "/data/" + genome_file_name
+            file_path = os.path.join(_TEST_DIR, "data", genome_file_name)
             features = []
             for record in SeqIO.parse(file_path, "fasta"):
                 id = record.id
@@ -493,3 +495,14 @@ class PanGenomeAPITest(unittest.TestCase):
         self.assertIn('features', ret['genomes'][0])
         self.assertIn('families', ret['genomes'][0])
         self.assertIn('functions', ret['genomes'][0])
+
+    def test_compute_summary_from_pangenome2_valid(self):
+        # Test object lives in a dedicated public test narrative owned by user `kbasedata`
+        ref = "51489/10/1"
+        params = {"pangenome_ref": ref}
+        ret = self.getImpl().compute_summary_from_pangenome2(self.getContext(), params)[0]
+        path = os.path.join(_TEST_DIR, "data", "summary2_expected_result.json")
+        # Assert against a full example object found in test/data/summary2_expected_result.json
+        with open(path) as fd:
+            expected = json.load(fd)
+        self.assertEqual(ret, expected)

--- a/test/data/summary2_expected_51489-10-1.json
+++ b/test/data/summary2_expected_51489-10-1.json
@@ -40,3 +40,4 @@
         "51489/8/1": "Shewanella amazonensis SB2B"
     }
 }
+

--- a/test/data/summary2_expected_51489-14-1.json
+++ b/test/data/summary2_expected_51489-14-1.json
@@ -1,0 +1,42 @@
+{
+    "pangenome_id": "pangenome_diff",
+    "genomes_count": 2,
+    "genes": {
+        "genes_count": 8494,
+        "homolog_family_genes_count": 4323,
+        "singleton_family_genes_count": 4171
+    },
+    "families": {
+        "families_count": 5915,
+        "homolog_families_count": 1744,
+        "singleton_families_count": 4171
+    },
+    "genomes": {
+        "Rhodobacter sphaeroides 2.4.1": {
+            "genome_genes": 4474,
+            "genome_homolog_family_genes": 2181,
+            "genome_homolog_family": 1511,
+            "genome_singleton_family_genes": 2293
+        },
+        "Shewanella oneidensis MR-1": {
+            "genome_genes": 4587,
+            "genome_homolog_family_genes": 2142,
+            "genome_homolog_family": 1470,
+            "genome_singleton_family_genes": 2445
+        }
+    },
+    "shared_family_map": {
+        "Rhodobacter sphaeroides 2.4.1": {
+            "Rhodobacter sphaeroides 2.4.1": 1511,
+            "Shewanella oneidensis MR-1": 1237
+        },
+        "Shewanella oneidensis MR-1": {
+            "Rhodobacter sphaeroides 2.4.1": 1237,
+            "Shewanella oneidensis MR-1": 1470
+        }
+    },
+    "genome_ref_name_map": {
+        "51489/13/1": "Rhodobacter sphaeroides 2.4.1",
+        "51489/9/1": "Shewanella oneidensis MR-1"
+    }
+}

--- a/test/data/summary2_expected_51489-15-1.json
+++ b/test/data/summary2_expected_51489-15-1.json
@@ -1,0 +1,42 @@
+{
+    "pangenome_id": "pangenome_otherapp",
+    "genomes_count": 2,
+    "genes": {
+        "genes_count": 7852,
+        "homolog_family_genes_count": 4759,
+        "singleton_family_genes_count": 3093
+    },
+    "families": {
+        "families_count": 5304,
+        "homolog_families_count": 2211,
+        "singleton_families_count": 3093
+    },
+    "genomes": {
+        "Shewanella amazonensis SB2B": {
+            "genome_genes": 3800,
+            "genome_homolog_family_genes": 2286,
+            "genome_homolog_family": 2170,
+            "genome_singleton_family_genes": 1514
+        },
+        "Shewanella oneidensis MR-1": {
+            "genome_genes": 4587,
+            "genome_homolog_family_genes": 2473,
+            "genome_homolog_family": 2195,
+            "genome_singleton_family_genes": 2114
+        }
+    },
+    "shared_family_map": {
+        "Shewanella amazonensis SB2B": {
+            "Shewanella amazonensis SB2B": 2170,
+            "Shewanella oneidensis MR-1": 2154
+        },
+        "Shewanella oneidensis MR-1": {
+            "Shewanella amazonensis SB2B": 2154,
+            "Shewanella oneidensis MR-1": 2195
+        }
+    },
+    "genome_ref_name_map": {
+        "51489/8/1": "Shewanella amazonensis SB2B",
+        "51489/9/1": "Shewanella oneidensis MR-1"
+    }
+}

--- a/test/data/summary2_expected_result.json
+++ b/test/data/summary2_expected_result.json
@@ -1,0 +1,42 @@
+{
+    "pangenome_id": "pangenome1",
+    "genomes_count": 2,
+    "genes": {
+        "genes_count": 7852,
+        "homolog_family_genes_count": 6112,
+        "singleton_family_genes_count": 1740
+    },
+    "families": {
+        "families_count": 4666,
+        "homolog_families_count": 2926,
+        "singleton_families_count": 1740
+    },
+    "genomes": {
+        "Shewanella oneidensis MR-1": {
+            "genome_genes": 4587,
+            "genome_homolog_family_genes": 3172,
+            "genome_homolog_family": 2877,
+            "genome_singleton_family_genes": 1415
+        },
+        "Shewanella amazonensis SB2B": {
+            "genome_genes": 3800,
+            "genome_homolog_family_genes": 2940,
+            "genome_homolog_family": 2835,
+            "genome_singleton_family_genes": 860
+        }
+    },
+    "shared_family_map": {
+        "Shewanella oneidensis MR-1": {
+            "Shewanella oneidensis MR-1": 2877,
+            "Shewanella amazonensis SB2B": 2786
+        },
+        "Shewanella amazonensis SB2B": {
+            "Shewanella oneidensis MR-1": 2786,
+            "Shewanella amazonensis SB2B": 2835
+        }
+    },
+    "genome_ref_name_map": {
+        "51489/9/1": "Shewanella oneidensis MR-1",
+        "51489/8/1": "Shewanella amazonensis SB2B"
+    }
+}


### PR DESCRIPTION
The compute_pangenome_summary function was fetching every genome in the pangenome, which was timing out in some cases due to size. All we need from the genomes are scientific name and feature count, so I refactored the function to only fetch object infos for the genomes in a single request.

While this should have the exact same API as the previous summary function, I did end up refactoring the code, so I'm adding it as a new method to be safe. The three valid case tests use expected results that I got from the older method, so those cases matches exactly.